### PR TITLE
fix(ui): Patch class-variance-authority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .yarn/*
 !.yarn/releases
 !.yarn/plugins
+!.yarn/patches
 .pnp.*
 
 # testing

--- a/.yarn/patches/class-variance-authority-npm-0.6.1-22a468e86e.patch
+++ b/.yarn/patches/class-variance-authority-npm-0.6.1-22a468e86e.patch
@@ -1,0 +1,71 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 676e466a43ad8932cbb3131bb2c3dea687d47041..cbffdc5191bd8535468fdeaf68365845d15804ea 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,21 +1,55 @@
++import type * as CLSX from "clsx";
+ import clsx from "clsx";
+-import type { ClassProp, ClassValue, OmitUndefined, StringToBoolean } from "./types";
+-export type VariantProps<Component extends (...args: any) => any> = Omit<OmitUndefined<Parameters<Component>[0]>, "class" | "className">;
++
++type ClassPropKey = "class" | "className";
++type ClassValue = CLSX.ClassValue;
++type ClassProp =
++  | {
++      class: ClassValue;
++      className?: never;
++    }
++  | {
++      class?: never;
++      className: ClassValue;
++    }
++  | {
++      class?: never;
++      className?: never;
++    };
++type OmitUndefined<T> = T extends undefined ? never : T;
++type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
++
++export type VariantProps<Component extends (...args: any) => any> = Omit<
++  OmitUndefined<Parameters<Component>[0]>,
++  "class" | "className"
++>;
+ export type CxOptions = Parameters<typeof clsx>;
+ export type CxReturn = ReturnType<typeof clsx>;
+ export declare const cx: typeof clsx;
+ type ConfigSchema = Record<string, Record<string, ClassValue>>;
+ type ConfigVariants<T extends ConfigSchema> = {
+-    [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | null | undefined;
++  [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | null | undefined;
+ };
+ type ConfigVariantsMulti<T extends ConfigSchema> = {
+-    [Variant in keyof T]?: StringToBoolean<keyof T[Variant]> | StringToBoolean<keyof T[Variant]>[] | undefined;
++  [Variant in keyof T]?:
++    | StringToBoolean<keyof T[Variant]>
++    | StringToBoolean<keyof T[Variant]>[]
++    | undefined;
+ };
+-type Config<T> = T extends ConfigSchema ? {
+-    variants?: T;
+-    defaultVariants?: ConfigVariants<T>;
+-    compoundVariants?: (T extends ConfigSchema ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp : ClassProp)[];
+-} : never;
+-type Props<T> = T extends ConfigSchema ? ConfigVariants<T> & ClassProp : ClassProp;
+-export declare const cva: <T>(base?: ClassValue, config?: Config<T> | undefined) => (props?: Props<T> | undefined) => string;
++type Config<T> = T extends ConfigSchema
++  ? {
++      variants?: T;
++      defaultVariants?: ConfigVariants<T>;
++      compoundVariants?: (T extends ConfigSchema
++        ? (ConfigVariants<T> | ConfigVariantsMulti<T>) & ClassProp
++        : ClassProp)[];
++    }
++  : never;
++type Props<T> = T extends ConfigSchema
++  ? ConfigVariants<T> & ClassProp
++  : ClassProp;
++export declare const cva: <T>(
++  base?: ClassValue,
++  config?: Config<T> | undefined
++) => (props?: Props<T> | undefined) => string;
+ export {};

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   "dependencies": {
     "@changesets/cli": "^2.26.1",
     "eslint-plugin-react-hooks": "^4.6.0"
+  },
+  "resolutions": {
+    "class-variance-authority@^0.6.1": "patch:class-variance-authority@npm%3A0.6.1#./.yarn/patches/class-variance-authority-npm-0.6.1-22a468e86e.patch"
   }
 }

--- a/packages/ui/src/components/badge/badge.stories.tsx
+++ b/packages/ui/src/components/badge/badge.stories.tsx
@@ -90,18 +90,18 @@ export const IconDefault: Story = {
 
 export const Small: Story = {
   args: {
-    size: "sm",
+    size: "small",
   },
 }
 
-export const Medium: Story = {
+export const Base: Story = {
   args: {
-    size: "md",
+    size: "base",
   },
 }
 
 export const Large: Story = {
   args: {
-    size: "lg",
+    size: "large",
   },
 }

--- a/packages/ui/src/components/badge/badge.tsx
+++ b/packages/ui/src/components/badge/badge.tsx
@@ -12,9 +12,9 @@ const badgeVariants = cva("inline-flex items-center gap-x-0.5 border", {
       icon: "rounded-md",
     },
     size: {
-      sm: "txt-compact-xsmall-plus px-1.5",
-      md: "txt-compact-small-plus px-2 py-0.5",
-      lg: "txt-compact-medium-plus px-2.5 py-1",
+      small: "txt-compact-xsmall-plus px-1.5",
+      base: "txt-compact-small-plus px-2 py-0.5",
+      large: "txt-compact-medium-plus px-2.5 py-1",
     },
     color: {
       green:
@@ -31,22 +31,22 @@ const badgeVariants = cva("inline-flex items-center gap-x-0.5 border", {
   compoundVariants: [
     {
       type: "icon",
-      size: "lg",
+      size: "large",
       className: "p-1",
     },
     {
       type: "icon",
-      size: "md",
+      size: "base",
       className: "p-0.5",
     },
     {
       type: "icon",
-      size: "sm",
+      size: "small",
       className: "p-0.5", // Icon does not get any smaller than `md`
     },
   ],
   defaultVariants: {
-    size: "md",
+    size: "base",
     type: "default",
     color: "grey",
   },

--- a/packages/ui/src/components/drawer/drawer.tsx
+++ b/packages/ui/src/components/drawer/drawer.tsx
@@ -4,10 +4,10 @@ import { XMark } from "@medusajs/icons"
 import * as Primitives from "@radix-ui/react-dialog"
 import * as React from "react"
 
-import { Badge } from "@/components/badge"
 import { Button } from "@/components/button"
 import { Heading } from "@/components/heading"
 import { clx } from "@/utils/clx"
+import { Kbd } from "../kbd"
 import { Text } from "../text"
 
 const Root = Primitives.Root
@@ -69,9 +69,7 @@ const Header = ({
     >
       <div className={clx("flex flex-col gap-y-1", className)}>{children}</div>
       <div className="flex items-center gap-x-2">
-        <Badge size={"sm"} color={"grey"}>
-          esc
-        </Badge>
+        <Kbd>esc</Kbd>
         <Close asChild>
           <Button variant="transparent" size={"sm"} format={"icon"}>
             <XMark />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7928,12 +7928,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-variance-authority@npm:^0.6.1":
+"class-variance-authority@npm:0.6.1":
   version: 0.6.1
   resolution: "class-variance-authority@npm:0.6.1"
   dependencies:
     clsx: 1.2.1
   checksum: 9be6b27998489c7af4535399ff00289c3347756209bb5405ca115e51bef7159f057f02532a53132299a3e26925552894ff1018bd8cc10807130b063039e82d8d
+  languageName: node
+  linkType: hard
+
+"class-variance-authority@patch:class-variance-authority@npm%3A0.6.1#./.yarn/patches/class-variance-authority-npm-0.6.1-22a468e86e.patch::locator=medusa-ui%40workspace%3A.":
+  version: 0.6.1
+  resolution: "class-variance-authority@patch:class-variance-authority@npm%3A0.6.1#./.yarn/patches/class-variance-authority-npm-0.6.1-22a468e86e.patch::version=0.6.1&hash=1b9fe4&locator=medusa-ui%40workspace%3A."
+  dependencies:
+    clsx: 1.2.1
+  checksum: 095af67867a627d20fcd214172afbd4a25350f7852078f1966d74692926c5832e2a20c8746724d514dbeab210252e82775bff2257fcf8e40f99c3d6e5fcfc445
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What**
- Variant props defined using `cva` and `VariantProps<typeof T>`, were not being included in the emitted types. This PR patches the package, to ensure that props get emitted correctly.

**How**
- Adds a `yarn` patch for `class-variance-authority` that ensures that types are exported correctly from the package.
