### PR TITLE
docs: Add examples for rest of components

### DIFF
--- a/apps/docs/src/config/docs.ts
+++ b/apps/docs/src/config/docs.ts
@@ -122,7 +122,7 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: "CodeBlock",
+          title: "Code Block",
           href: "/docs/components/code-block",
           items: [],
         },
@@ -142,7 +142,7 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: "DatePicker",
+          title: "Date Picker",
           href: "/docs/components/date-picker",
           items: [],
         },
@@ -152,12 +152,12 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: "DropdownMenu",
+          title: "Dropdown Menu",
           href: "/docs/components/dropdown-menu",
           items: [],
         },
         {
-          title: "FocusModal",
+          title: "Focus Modal",
           href: "/docs/components/focus-modal",
           items: [],
         },
@@ -187,7 +187,7 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: "RadioGroup",
+          title: "Radio Group",
           href: "/docs/components/radio-group",
           items: [],
         },

--- a/apps/docs/src/content/docs/components/avatar.mdx
+++ b/apps/docs/src/content/docs/components/avatar.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Avatar} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/calendar.mdx
+++ b/apps/docs/src/content/docs/components/calendar.mdx
@@ -1,12 +1,14 @@
 ---
 title: "Calendar"
-description: "TBA"
+description: "A calendar component that allows picking of a single date or a range of dates."
 component: true
 ---
 
 <ComponentExample name="calendar-demo" />
 
 ## Usage
+
+---
 
 <Snippet>```import {Calendar} from "@medusajs/ui"```</Snippet>
 
@@ -15,3 +17,15 @@ component: true
   <Calendar />
   ```
 </Snippet>
+
+## Examples
+
+---
+
+### Single Date
+
+<ComponentExample name="calendar-single" />
+
+### Range
+
+<ComponentExample name="calendar-range" />

--- a/apps/docs/src/content/docs/components/checkbox.mdx
+++ b/apps/docs/src/content/docs/components/checkbox.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Checkbox} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
@@ -15,3 +17,23 @@ component: true
   <Checkbox />
   ```
 </Snippet>
+
+## Examples
+
+---
+
+### Default
+
+<ComponentExample name="checkbox-default" />
+
+### Checked
+
+<ComponentExample name="checkbox-checked" />
+
+### Disabled
+
+<ComponentExample name="checkbox-disabled" />
+
+### Indeterminate
+
+<ComponentExample name="checkbox-indeterminate" />

--- a/apps/docs/src/content/docs/components/code-block.mdx
+++ b/apps/docs/src/content/docs/components/code-block.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {CodeBlock} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
@@ -27,3 +29,23 @@ component: true
   
   ```
 </Snippet>
+
+## Examples
+
+---
+
+### Single snippet
+
+If you want to only show a code sample for one language or API, you can choose to hide the snippet labels:
+
+<ComponentExample name="code-block-single" />
+
+### No Header
+
+You could also choose to omit the header entirely:
+
+<ComponentExample name="code-block-no-header" />
+
+### No Line Numbers
+
+<ComponentExample name="code-block-no-lines" />

--- a/apps/docs/src/content/docs/components/command.mdx
+++ b/apps/docs/src/content/docs/components/command.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Command} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/container.mdx
+++ b/apps/docs/src/content/docs/components/container.mdx
@@ -8,8 +8,18 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Container} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
   ```<Container>Container</Container>```
 </Snippet>
+
+## Examples
+
+---
+
+### In a layout
+
+<ComponentExample name="container-layout" />

--- a/apps/docs/src/content/docs/components/copy.mdx
+++ b/apps/docs/src/content/docs/components/copy.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Copy} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/drawer.mdx
+++ b/apps/docs/src/content/docs/components/drawer.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Drawer} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/dropdown-menu.mdx
+++ b/apps/docs/src/content/docs/components/dropdown-menu.mdx
@@ -1,5 +1,5 @@
 ---
-title: "DropdownMenu"
+title: "Dropdown Menu"
 description: "Displays a menu to the user—such as a set of actions or functions—triggered by a button."
 component: true
 ---
@@ -7,6 +7,8 @@ component: true
 <ComponentExample name="dropdown-menu-demo" />
 
 ## Usage
+
+---
 
 <Snippet>```import {DropdownMenu} from "@medusajs/ui"```</Snippet>
 
@@ -22,3 +24,13 @@ component: true
   </DropdownMenu>
   ```
 </Snippet>
+
+## Examples
+
+---
+
+### Sorting
+
+Implementing collection sorting choices using a Dropdown Menu:
+
+<ComponentExample name="dropdown-menu-sorting" />

--- a/apps/docs/src/content/docs/components/focus-modal.mdx
+++ b/apps/docs/src/content/docs/components/focus-modal.mdx
@@ -1,5 +1,5 @@
 ---
-title: "FocusModal"
+title: "Focus Modal"
 description: "A modal component that spans the whole screen"
 component: true
 ---
@@ -7,6 +7,8 @@ component: true
 <ComponentExample name="focus-modal-demo" />
 
 ## Usage
+
+---
 
 <Snippet>```import {FocusModal} from "@medusajs/ui"```</Snippet>
 

--- a/apps/docs/src/content/docs/components/heading.mdx
+++ b/apps/docs/src/content/docs/components/heading.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Heading} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/input.mdx
+++ b/apps/docs/src/content/docs/components/input.mdx
@@ -37,3 +37,9 @@ component: true
 ### Small
 
 <ComponentExample name="input-small" />
+
+### Error state
+
+You can leverage the native `aria-invalid` property to show an error state on your input:
+
+<ComponentExample name="input-error" />

--- a/apps/docs/src/content/docs/components/kbd.mdx
+++ b/apps/docs/src/content/docs/components/kbd.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Kbd} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/prompt.mdx
+++ b/apps/docs/src/content/docs/components/prompt.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Prompt} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/radio-group.mdx
+++ b/apps/docs/src/content/docs/components/radio-group.mdx
@@ -1,5 +1,5 @@
 ---
-title: "RadioGroup"
+title: "Radio Group"
 description: "A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time."
 component: true
 ---
@@ -8,14 +8,28 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {RadioGroup} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
   ```
-  <RadioGroup.Root>
+  <RadioGroup>
     <RadioGroup.Item value="1" id="radio_1" />
     <RadioGroup.Item value="2" id="radio_2" />
     <RadioGroup.Item value="3" id="radio_3" />
-  </RadioGroup.Root>
+  </RadioGroup>
   ```
 </Snippet>
+
+## Examples
+
+---
+
+### With Descriptions
+
+<ComponentExample name="radio-group-descriptions" />
+
+### With a disabled item
+
+<ComponentExample name="radio-group-disabled" />

--- a/apps/docs/src/content/docs/components/switch.mdx
+++ b/apps/docs/src/content/docs/components/switch.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Switch} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
@@ -15,3 +17,23 @@ component: true
   <Switch />
   ```
 </Snippet>
+
+## Examples
+
+---
+
+### Small
+
+<ComponentExample name="switch-small" />
+
+### Disabled
+
+<ComponentExample name="switch-disabled" />
+
+### Checked
+
+<ComponentExample name="switch-checked" />
+
+### Checked Disabled
+
+<ComponentExample name="switch-checked-disabled" />

--- a/apps/docs/src/content/docs/components/table.mdx
+++ b/apps/docs/src/content/docs/components/table.mdx
@@ -7,25 +7,27 @@ description: "A Table component for displaying data."
 
 ## Usage
 
+---
+
 <Snippet>```import {Table} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
   ```
-   <Table>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>#</Table.HeaderCell>
-          <Table.HeaderCell>Customer</Table.HeaderCell>
-          <Table.HeaderCell>Email</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>1</Table.Cell>
-          <Table.Cell>Emil Larsson</Table.Cell>
-          <Table.Cell>emil2738@gmail.com</Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table>
+  <Table>
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>#</Table.HeaderCell>
+        <Table.HeaderCell>Customer</Table.HeaderCell>
+        <Table.HeaderCell>Email</Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>1</Table.Cell>
+        <Table.Cell>Emil Larsson</Table.Cell>
+        <Table.Cell>emil2738@gmail.com</Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table>
   ```
 </Snippet>

--- a/apps/docs/src/content/docs/components/text.mdx
+++ b/apps/docs/src/content/docs/components/text.mdx
@@ -8,8 +8,18 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Text} from "@medusajs/ui"```</Snippet>
 
 <Snippet>
   ```<Text>Text</Text>```
 </Snippet>
+
+## Examples
+
+---
+
+### All variations
+
+<ComponentExample name="text-examples" />

--- a/apps/docs/src/content/docs/components/textarea.mdx
+++ b/apps/docs/src/content/docs/components/textarea.mdx
@@ -8,6 +8,8 @@ component: true
 
 ## Usage
 
+---
+
 <Snippet>```import {Textarea} from "@medusajs/ui"```</Snippet>
 
 <Snippet>

--- a/apps/docs/src/content/docs/components/toast.mdx
+++ b/apps/docs/src/content/docs/components/toast.mdx
@@ -8,6 +8,9 @@ component: true
 
 ## Usage
 
+---
+
+<br />
 Add the Toaster component somewhere in your tree
 
 <Snippet>```import {Toaster} from "@medusajs/ui"```</Snippet>
@@ -27,7 +30,6 @@ The `useToast` hook returns a `toast` function that you can use to display a toa
 const { toast } = useToast()
 
 return (
-
   <Button 
     onClick={() => 
       toast({ 
@@ -41,3 +43,27 @@ return (
 )
 ```
 </Snippet>
+
+## Examples
+
+---
+
+### Warning
+
+<ComponentExample name="toaster-warning" />
+
+### Error
+
+<ComponentExample name="toaster-error" />
+
+### Success
+
+<ComponentExample name="toaster-success" />
+
+### Loading
+
+<ComponentExample name="toaster-loading" />
+
+### With Action
+
+<ComponentExample name="toaster-with-action" />

--- a/apps/docs/src/examples/calendar-range.tsx
+++ b/apps/docs/src/examples/calendar-range.tsx
@@ -1,0 +1,13 @@
+import { Calendar } from "@medusajs/ui"
+import * as React from "react"
+import type { DateRange } from "react-day-picker"
+
+export default function CalendarRange() {
+  const [dates, setDates] = React.useState<DateRange | undefined>()
+
+  const setDateRange = (range: DateRange | undefined) => {
+    setDates(range)
+  }
+
+  return <Calendar selected={dates} onSelect={setDateRange} mode="range" />
+}

--- a/apps/docs/src/examples/calendar-single.tsx
+++ b/apps/docs/src/examples/calendar-single.tsx
@@ -1,0 +1,8 @@
+import { Calendar } from "@medusajs/ui"
+import * as React from "react"
+
+export default function CalendarSingle() {
+  const [date, setDate] = React.useState<Date | undefined>()
+
+  return <Calendar selected={date} onSelect={setDate} />
+}

--- a/apps/docs/src/examples/checkbox-checked.tsx
+++ b/apps/docs/src/examples/checkbox-checked.tsx
@@ -1,0 +1,12 @@
+import { Checkbox, Label } from "@medusajs/ui"
+
+export default function CheckboxChecked() {
+  return (
+    <div className="flex items-center space-x-2">
+      <Checkbox id="billing-shipping-checked" checked={true} />
+      <Label htmlFor="billing-shipping-checked">
+        Billing address same as shipping address
+      </Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/checkbox-default.tsx
+++ b/apps/docs/src/examples/checkbox-default.tsx
@@ -1,0 +1,12 @@
+import { Checkbox, Label } from "@medusajs/ui"
+
+export default function CheckboxDefault() {
+  return (
+    <div className="flex items-center space-x-2">
+      <Checkbox id="billing-shipping-default" />
+      <Label htmlFor="billing-shipping-default">
+        Billing address same as shipping address
+      </Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/checkbox-disabled.tsx
+++ b/apps/docs/src/examples/checkbox-disabled.tsx
@@ -1,0 +1,12 @@
+import { Checkbox, Label } from "@medusajs/ui"
+
+export default function CheckboxDisabled() {
+  return (
+    <div className="flex items-center space-x-2">
+      <Checkbox id="billing-shipping-disabled" disabled={true} />
+      <Label htmlFor="billing-shipping-disabled">
+        Billing address same as shipping address
+      </Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/checkbox-indeterminate.tsx
+++ b/apps/docs/src/examples/checkbox-indeterminate.tsx
@@ -1,0 +1,12 @@
+import { Checkbox, Label } from "@medusajs/ui"
+
+export default function CheckboxIndeterminate() {
+  return (
+    <div className="flex items-center space-x-2">
+      <Checkbox id="billing-shipping-indeterminate" checked={"indeterminate"} />
+      <Label htmlFor="billing-shipping-indeterminate">
+        Billing address same as shipping address
+      </Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/code-block-no-header.tsx
+++ b/apps/docs/src/examples/code-block-no-header.tsx
@@ -1,0 +1,19 @@
+import { CodeBlock, Label } from "@medusajs/ui"
+
+const snippets = [
+  {
+    label: "Medusa React",
+    language: "tsx",
+    code: `import { useProduct } from "medusa-react"\n\nconst { product } = useProduct("PRODUCT_ID")\nconsole.log(product.id)`,
+  },
+]
+
+export default function CodeBlockNoHeader() {
+  return (
+    <div className="w-full">
+      <CodeBlock snippets={snippets}>
+        <CodeBlock.Body />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/code-block-no-lines.tsx
+++ b/apps/docs/src/examples/code-block-no-lines.tsx
@@ -1,0 +1,24 @@
+import { CodeBlock, Label } from "@medusajs/ui"
+
+const snippets = [
+  {
+    label: "Medusa React",
+    language: "tsx",
+    code: `import { useProduct } from "medusa-react"\n\nconst { product } = useProduct("PRODUCT_ID")\nconsole.log(product.id)`,
+  },
+]
+
+export default function CodeBlockNoLines() {
+  return (
+    <div className="w-full">
+      <CodeBlock snippets={snippets}>
+        <CodeBlock.Header>
+          <CodeBlock.Header.Meta>
+            <Label weight={"plus"}>/product-detail.js</Label>
+          </CodeBlock.Header.Meta>
+        </CodeBlock.Header>
+        <CodeBlock.Body hideLineNumbers={true} />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/code-block-single.tsx
+++ b/apps/docs/src/examples/code-block-single.tsx
@@ -1,0 +1,24 @@
+import { CodeBlock, Label } from "@medusajs/ui"
+
+const snippets = [
+  {
+    label: "Medusa React",
+    language: "tsx",
+    code: `import { useProduct } from "medusa-react"\n\nconst { product } = useProduct("PRODUCT_ID")\nconsole.log(product.id)`,
+  },
+]
+
+export default function CodeBlockSingle() {
+  return (
+    <div className="w-full">
+      <CodeBlock snippets={snippets}>
+        <CodeBlock.Header hideLabels={true}>
+          <CodeBlock.Header.Meta>
+            <Label weight={"plus"}>/product-detail.js</Label>
+          </CodeBlock.Header.Meta>
+        </CodeBlock.Header>
+        <CodeBlock.Body />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/container-layout.tsx
+++ b/apps/docs/src/examples/container-layout.tsx
@@ -1,0 +1,22 @@
+import { Container, Heading } from "@medusajs/ui"
+
+export default function ContainerLayout() {
+  return (
+    <div className="flex h-full w-full">
+      <div className="border-ui-border-base w-full max-w-[216px] border-r p-4">
+        <Heading level="h3">Menubar</Heading>
+      </div>
+      <div className="flex w-full flex-col gap-y-2 px-8 pb-8 pt-6">
+        <Container>
+          <Heading>Section 1</Heading>
+        </Container>
+        <Container>
+          <Heading>Section 2</Heading>
+        </Container>
+        <Container>
+          <Heading>Section 3</Heading>
+        </Container>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/dropdown-menu-sorting.tsx
+++ b/apps/docs/src/examples/dropdown-menu-sorting.tsx
@@ -1,0 +1,51 @@
+import { EllipsisHorizontal } from "@medusajs/icons"
+import { Button, DropdownMenu } from "@medusajs/ui"
+import React from "react"
+
+type SortingState = "asc" | "desc" | "alpha" | "alpha-reverse" | "none"
+
+export default function DropdownMenuSorting() {
+  const [sort, setSort] = React.useState<SortingState>("none")
+
+  return (
+    <div className="flex flex-col items-center gap-y-2">
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <Button variant="secondary" format={"icon"}>
+            <EllipsisHorizontal />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content className="w-[300px]">
+          <DropdownMenu.RadioGroup
+            value={sort}
+            onValueChange={(v) => setSort(v as SortingState)}
+          >
+            <DropdownMenu.RadioItem value="none">
+              No Sorting
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.Separator />
+            <DropdownMenu.RadioItem value="alpha">
+              Alphabetical
+              <DropdownMenu.Hint>A-Z</DropdownMenu.Hint>
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="alpha-reverse">
+              Reverse Alphabetical
+              <DropdownMenu.Hint>Z-A</DropdownMenu.Hint>
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="asc">
+              Created At - Ascending
+              <DropdownMenu.Hint>1 - 30</DropdownMenu.Hint>
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="desc">
+              Created At - Descending
+              <DropdownMenu.Hint>30 - 1</DropdownMenu.Hint>
+            </DropdownMenu.RadioItem>
+          </DropdownMenu.RadioGroup>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+      <div>
+        <pre className=" text-sm">Sorting: {sort}</pre>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/input-error.tsx
+++ b/apps/docs/src/examples/input-error.tsx
@@ -1,0 +1,13 @@
+import { Input } from "@medusajs/ui"
+
+export default function InputError() {
+  return (
+    <div className="w-[250px]">
+      <Input
+        placeholder="Sales Channel Name"
+        id="sales-channel-name"
+        aria-invalid={true}
+      />
+    </div>
+  )
+}

--- a/apps/docs/src/examples/radio-group-demo.tsx
+++ b/apps/docs/src/examples/radio-group-demo.tsx
@@ -2,7 +2,7 @@ import { Label, RadioGroup } from "@medusajs/ui"
 
 export default function RadioGroupDemo() {
   return (
-    <RadioGroup.Root>
+    <RadioGroup>
       <div className="flex items-center gap-x-3">
         <RadioGroup.Item value="1" id="radio_1" />
         <Label htmlFor="radio_1" weight="plus">
@@ -21,6 +21,6 @@ export default function RadioGroupDemo() {
           Radio 3
         </Label>
       </div>
-    </RadioGroup.Root>
+    </RadioGroup>
   )
 }

--- a/apps/docs/src/examples/radio-group-descriptions.tsx
+++ b/apps/docs/src/examples/radio-group-descriptions.tsx
@@ -1,0 +1,41 @@
+import { Label, RadioGroup, Text } from "@medusajs/ui"
+
+export default function RadioGroupDescriptions() {
+  return (
+    <RadioGroup>
+      <div className="flex items-start gap-x-3">
+        <RadioGroup.Item value="1" id="radio_1_descriptions" />
+        <div className="flex flex-col gap-y-0.5">
+          <Label htmlFor="radio_1_descriptions" weight="plus">
+            Radio 1
+          </Label>
+          <Text className="text-ui-fg-subtle">
+            The quick brown fox jumps over the lazy dog.
+          </Text>
+        </div>
+      </div>
+      <div className="flex items-start gap-x-3">
+        <RadioGroup.Item value="2" id="radio_2_descriptions" />
+        <div className="flex flex-col gap-y-0.5">
+          <Label htmlFor="radio_2_descriptions" weight="plus">
+            Radio 2
+          </Label>
+          <Text className="text-ui-fg-subtle">
+            The quick brown fox jumps over the lazy dog.
+          </Text>
+        </div>
+      </div>
+      <div className="flex items-start gap-x-3">
+        <RadioGroup.Item value="3" id="radio_3_descriptions" />
+        <div className="flex flex-col gap-y-0.5">
+          <Label htmlFor="radio_3_descriptions" weight="plus">
+            Radio 3
+          </Label>
+          <Text className="text-ui-fg-subtle">
+            The quick brown fox jumps over the lazy dog.
+          </Text>
+        </div>
+      </div>
+    </RadioGroup>
+  )
+}

--- a/apps/docs/src/examples/radio-group-disabled.tsx
+++ b/apps/docs/src/examples/radio-group-disabled.tsx
@@ -1,0 +1,26 @@
+import { Label, RadioGroup } from "@medusajs/ui"
+
+export default function RadioGroupDisabled() {
+  return (
+    <RadioGroup>
+      <div className="flex items-center gap-x-3">
+        <RadioGroup.Item value="1" id="radio_1_disabled" />
+        <Label htmlFor="radio_1_disabled" weight="plus">
+          Radio 1
+        </Label>
+      </div>
+      <div className="flex items-center gap-x-3">
+        <RadioGroup.Item value="2" id="radio_2_disabled" />
+        <Label htmlFor="radio_2_disabled" weight="plus">
+          Radio 2
+        </Label>
+      </div>
+      <div className="flex items-center gap-x-3">
+        <RadioGroup.Item value="3" id="radio_3_disabled" disabled={true} />
+        <Label htmlFor="radio_3_disabled" weight="plus">
+          Radio 3
+        </Label>
+      </div>
+    </RadioGroup>
+  )
+}

--- a/apps/docs/src/examples/switch-checked-disabled.tsx
+++ b/apps/docs/src/examples/switch-checked-disabled.tsx
@@ -1,0 +1,16 @@
+import { Label, Switch } from "@medusajs/ui"
+
+export default function SwitchCheckedDisabled() {
+  return (
+    <div className="flex items-center gap-x-2">
+      <Switch
+        id="manage-inventory-checked-disabled"
+        checked={true}
+        disabled={true}
+      />
+      <Label htmlFor="manage-inventory-checked-disabled">
+        Manage Inventory
+      </Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/switch-checked.tsx
+++ b/apps/docs/src/examples/switch-checked.tsx
@@ -1,0 +1,10 @@
+import { Label, Switch } from "@medusajs/ui"
+
+export default function SwitchChecked() {
+  return (
+    <div className="flex items-center gap-x-2">
+      <Switch id="manage-inventory-checked" checked={true} />
+      <Label htmlFor="manage-inventory-checked">Manage Inventory</Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/switch-disabled.tsx
+++ b/apps/docs/src/examples/switch-disabled.tsx
@@ -3,7 +3,7 @@ import { Label, Switch } from "@medusajs/ui"
 export default function SwitchDisabled() {
   return (
     <div className="flex items-center gap-x-2">
-      <Switch id="manage-inventory-disabled" diasbled={true} />
+      <Switch id="manage-inventory-disabled" disabled={true} />
       <Label htmlFor="manage-inventory-disabled">Manage Inventory</Label>
     </div>
   )

--- a/apps/docs/src/examples/switch-disabled.tsx
+++ b/apps/docs/src/examples/switch-disabled.tsx
@@ -1,0 +1,10 @@
+import { Label, Switch } from "@medusajs/ui"
+
+export default function SwitchDisabled() {
+  return (
+    <div className="flex items-center gap-x-2">
+      <Switch id="manage-inventory-disabled" diasbled={true} />
+      <Label htmlFor="manage-inventory-disabled">Manage Inventory</Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/switch-small.tsx
+++ b/apps/docs/src/examples/switch-small.tsx
@@ -1,0 +1,12 @@
+import { Label, Switch } from "@medusajs/ui"
+
+export default function SwitchSmall() {
+  return (
+    <div className="flex items-center gap-x-2">
+      <Switch id="manage-inventory-small" size="small" />
+      <Label htmlFor="manage-inventory-small" size="small">
+        Manage Inventory
+      </Label>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/text-examples.tsx
+++ b/apps/docs/src/examples/text-examples.tsx
@@ -1,0 +1,41 @@
+import { Text } from "@medusajs/ui"
+
+export default function TextExamples() {
+  return (
+    <div className="flex flex-col items-start gap-y-2">
+      <Text size="base" weight="regular" family="sans">
+        Base Size, Regular Weight, Sans-Serif
+      </Text>
+      <Text size="base" weight="plus" family="sans">
+        Base Size, Plus Weight, Sans-Serif
+      </Text>
+      <Text size="large" weight="regular" family="sans">
+        Large Size, Regular Weight, Sans-Serif
+      </Text>
+      <Text size="large" weight="plus" family="sans">
+        Large Size, Plus Weight, Sans-Serif
+      </Text>
+      <Text size="xlarge" weight="regular" family="sans">
+        XLarge Size, Regular Weight, Sans-Serif
+      </Text>
+      <Text size="xlarge" weight="plus" family="sans">
+        XLarge Size, Plus Weight, Sans-Serif
+      </Text>
+      <Text size="base" weight="regular" family="mono">
+        Base Size, Regular Weight, Mono
+      </Text>
+      <Text size="large" weight="regular" family="mono">
+        Large Size, Regular Weight, Mono
+      </Text>
+      <Text size="large" weight="plus" family="mono">
+        Large Size, Plus Weight, Mono
+      </Text>
+      <Text size="xlarge" weight="regular" family="mono">
+        XLarge Size, Regular Weight, Mono
+      </Text>
+      <Text size="xlarge" weight="plus" family="mono">
+        XLarge Size, Plus Weight, Mono
+      </Text>
+    </div>
+  )
+}

--- a/apps/docs/src/examples/toaster-error.tsx
+++ b/apps/docs/src/examples/toaster-error.tsx
@@ -1,0 +1,23 @@
+import { Button, Toaster, useToast } from "@medusajs/ui"
+
+export default function ToasterError() {
+  const { toast } = useToast()
+
+  return (
+    <>
+      <Toaster />
+      <Button
+        onClick={() =>
+          toast({
+            title: "Error",
+            description: "The quick brown fox jumps over the lazy dog.",
+            variant: "error",
+            duration: 5000,
+          })
+        }
+      >
+        Show
+      </Button>
+    </>
+  )
+}

--- a/apps/docs/src/examples/toaster-loading.tsx
+++ b/apps/docs/src/examples/toaster-loading.tsx
@@ -1,0 +1,23 @@
+import { Button, Toaster, useToast } from "@medusajs/ui"
+
+export default function ToasterLoading() {
+  const { toast } = useToast()
+
+  return (
+    <>
+      <Toaster />
+      <Button
+        onClick={() =>
+          toast({
+            title: "Loading",
+            description: "The quick brown fox jumps over the lazy dog.",
+            variant: "loading",
+            duration: 5000,
+          })
+        }
+      >
+        Show
+      </Button>
+    </>
+  )
+}

--- a/apps/docs/src/examples/toaster-success.tsx
+++ b/apps/docs/src/examples/toaster-success.tsx
@@ -1,0 +1,23 @@
+import { Button, Toaster, useToast } from "@medusajs/ui"
+
+export default function ToasterSuccess() {
+  const { toast } = useToast()
+
+  return (
+    <>
+      <Toaster />
+      <Button
+        onClick={() =>
+          toast({
+            title: "Success",
+            description: "The quick brown fox jumps over the lazy dog.",
+            variant: "success",
+            duration: 5000,
+          })
+        }
+      >
+        Show
+      </Button>
+    </>
+  )
+}

--- a/apps/docs/src/examples/toaster-warning.tsx
+++ b/apps/docs/src/examples/toaster-warning.tsx
@@ -1,0 +1,23 @@
+import { Button, Toaster, useToast } from "@medusajs/ui"
+
+export default function ToasterWarning() {
+  const { toast } = useToast()
+
+  return (
+    <>
+      <Toaster />
+      <Button
+        onClick={() =>
+          toast({
+            title: "Warning",
+            description: "The quick brown fox jumps over the lazy dog.",
+            variant: "warning",
+            duration: 5000,
+          })
+        }
+      >
+        Show
+      </Button>
+    </>
+  )
+}

--- a/apps/docs/src/examples/toaster-with-action.tsx
+++ b/apps/docs/src/examples/toaster-with-action.tsx
@@ -1,0 +1,28 @@
+import { Button, Toaster, useToast } from "@medusajs/ui"
+
+export default function ToasterWithAction() {
+  const { toast } = useToast()
+
+  return (
+    <>
+      <Toaster />
+      <Button
+        onClick={() =>
+          toast({
+            title: "Created Product",
+            description: "The product has been created.",
+            variant: "success",
+            action: {
+              altText: "Undo product creation",
+              onClick: () => {},
+              label: "Undo",
+            },
+            duration: 10000,
+          })
+        }
+      >
+        Show
+      </Button>
+    </>
+  )
+}

--- a/apps/docs/src/registry.tsx
+++ b/apps/docs/src/registry.tsx
@@ -192,6 +192,11 @@ export const Registry: Record<string, any> = {
     component: React.lazy(() => import("@/examples/input-small")),
     file: "src/examples/input-small.tsx",
   },
+  "input-error": {
+    name: "input-error",
+    component: React.lazy(() => import("@/examples/input-error")),
+    file: "src/examples/input-error.tsx",
+  },
   "kbd-demo": {
     name: "kbd-demo",
     component: React.lazy(() => import("@/examples/kbd-demo")),
@@ -212,6 +217,16 @@ export const Registry: Record<string, any> = {
     component: React.lazy(() => import("@/examples/radio-group-demo")),
     file: "src/examples/radio-group-demo.tsx",
   },
+  "radio-group-descriptions": {
+    name: "radio-group-descriptions",
+    component: React.lazy(() => import("@/examples/radio-group-descriptions")),
+    file: "src/examples/radio-group-descriptions.tsx",
+  },
+  "radio-group-disabled": {
+    name: "radio-group-disabled",
+    component: React.lazy(() => import("@/examples/radio-group-disabled")),
+    file: "src/examples/radio-group-disabled.tsx",
+  },
   "select-demo": {
     name: "select-demo",
     component: React.lazy(() => import("@/examples/select-demo")),
@@ -221,6 +236,26 @@ export const Registry: Record<string, any> = {
     name: "switch-demo",
     component: React.lazy(() => import("@/examples/switch-demo")),
     file: "src/examples/switch-demo.tsx",
+  },
+  "switch-small": {
+    name: "switch-small",
+    component: React.lazy(() => import("@/examples/switch-small")),
+    file: "src/examples/switch-small.tsx",
+  },
+  "switch-disabled": {
+    name: "switch-disabled",
+    component: React.lazy(() => import("@/examples/switch-disabled")),
+    file: "src/examples/switch-disabled.tsx",
+  },
+  "switch-checked": {
+    name: "switch-checked",
+    component: React.lazy(() => import("@/examples/switch-checked")),
+    file: "src/examples/switch-checked.tsx",
+  },
+  "switch-checked-disabled": {
+    name: "switch-checked-disabled",
+    component: React.lazy(() => import("@/examples/switch-checked-disabled")),
+    file: "src/examples/switch-checked-disabled.tsx",
   },
   "table-demo": {
     name: "table-demo",
@@ -232,6 +267,11 @@ export const Registry: Record<string, any> = {
     component: React.lazy(() => import("@/examples/text-demo")),
     file: "src/examples/text-demo.tsx",
   },
+  "text-examples": {
+    name: "text-examples",
+    component: React.lazy(() => import("@/examples/text-examples")),
+    file: "src/examples/text-examples.tsx",
+  },
   "textarea-demo": {
     name: "textarea-demo",
     component: React.lazy(() => import("@/examples/textarea-demo")),
@@ -241,6 +281,31 @@ export const Registry: Record<string, any> = {
     name: "toaster-demo",
     component: React.lazy(() => import("@/examples/toaster-demo")),
     file: "src/examples/toaster-demo.tsx",
+  },
+  "toaster-warning": {
+    name: "toaster-warning",
+    component: React.lazy(() => import("@/examples/toaster-warning")),
+    file: "src/examples/toaster-warning.tsx",
+  },
+  "toaster-error": {
+    name: "toaster-error",
+    component: React.lazy(() => import("@/examples/toaster-error")),
+    file: "src/examples/toaster-error.tsx",
+  },
+  "toaster-success": {
+    name: "toaster-success",
+    component: React.lazy(() => import("@/examples/toaster-success")),
+    file: "src/examples/toaster-success.tsx",
+  },
+  "toaster-loading": {
+    name: "toaster-loading",
+    component: React.lazy(() => import("@/examples/toaster-loading")),
+    file: "src/examples/toaster-loading.tsx",
+  },
+  "toaster-with-action": {
+    name: "toaster-with-action",
+    component: React.lazy(() => import("@/examples/toaster-with-action")),
+    file: "src/examples/toaster-with-action.tsx",
   },
   "tooltip-demo": {
     name: "tooltip-demo",
@@ -378,5 +443,60 @@ export const Registry: Record<string, any> = {
     name: "label-xsmall-regular",
     component: React.lazy(() => import("@/examples/label-xsmall-plus")),
     file: "src/examples/label-xsmall-plus.tsx",
+  },
+  "calendar-single": {
+    name: "calendar-single",
+    component: React.lazy(() => import("@/examples/calendar-single")),
+    file: "src/examples/calendar-single.tsx",
+  },
+  "calendar-range": {
+    name: "calendar-range",
+    component: React.lazy(() => import("@/examples/calendar-range")),
+    file: "src/examples/calendar-range.tsx",
+  },
+  "checkbox-default": {
+    name: "checkbox-default",
+    component: React.lazy(() => import("@/examples/checkbox-default")),
+    file: "src/examples/checkbox-default.tsx",
+  },
+  "checkbox-checked": {
+    name: "checkbox-checked",
+    component: React.lazy(() => import("@/examples/checkbox-checked")),
+    file: "src/examples/checkbox-checked.tsx",
+  },
+  "checkbox-disabled": {
+    name: "checkbox-disabled",
+    component: React.lazy(() => import("@/examples/checkbox-disabled")),
+    file: "src/examples/checkbox-disabled.tsx",
+  },
+  "checkbox-indeterminate": {
+    name: "checkbox-indeterminate",
+    component: React.lazy(() => import("@/examples/checkbox-indeterminate")),
+    file: "src/examples/checkbox-indeterminate.tsx",
+  },
+  "code-block-single": {
+    name: "code-block-single",
+    component: React.lazy(() => import("@/examples/code-block-single")),
+    file: "src/examples/code-block-single.tsx",
+  },
+  "code-block-no-lines": {
+    name: "code-block-no-lines",
+    component: React.lazy(() => import("@/examples/code-block-no-lines")),
+    file: "src/examples/code-block-no-lines.tsx",
+  },
+  "code-block-no-header": {
+    name: "code-block-no-header",
+    component: React.lazy(() => import("@/examples/code-block-no-header")),
+    file: "src/examples/code-block-no-header.tsx",
+  },
+  "container-layout": {
+    name: "container-layout",
+    component: React.lazy(() => import("@/examples/container-layout")),
+    file: "src/examples/container-layout.tsx",
+  },
+  "dropdown-menu-sorting": {
+    name: "dropdown-menu-sorting",
+    component: React.lazy(() => import("@/examples/dropdown-menu-sorting")),
+    file: "src/examples/dropdown-menu-sorting.tsx",
   },
 }

--- a/packages/ui/src/components/code-block/code-block.tsx
+++ b/packages/ui/src/components/code-block/code-block.tsx
@@ -57,11 +57,16 @@ const Root = ({
   )
 }
 
+type HeaderProps = {
+  hideLabels?: boolean
+}
+
 const HeaderComponent = ({
   children,
   className,
+  hideLabels = false,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => {
+}: React.HTMLAttributes<HTMLDivElement> & HeaderProps) => {
   const { snippets, active, setActive } = useCodeBlockContext()
   return (
     <div
@@ -71,21 +76,22 @@ const HeaderComponent = ({
       )}
       {...props}
     >
-      {snippets.map((snippet) => (
-        <div
-          className={clx(
-            "text-ui-code-text-subtle txt-compact-small-plus cursor-pointer rounded-full border border-transparent px-3 py-2 transition-all",
-            {
-              "text-ui-code-text-base border-ui-code-border bg-ui-code-bg-base cursor-default":
-                active.label === snippet.label,
-            }
-          )}
-          key={snippet.label}
-          onClick={() => setActive(snippet)}
-        >
-          {snippet.label}
-        </div>
-      ))}
+      {!hideLabels &&
+        snippets.map((snippet) => (
+          <div
+            className={clx(
+              "text-ui-code-text-subtle txt-compact-small-plus cursor-pointer rounded-full border border-transparent px-3 py-2 transition-all",
+              {
+                "text-ui-code-text-base border-ui-code-border bg-ui-code-bg-base cursor-default":
+                  active.label === snippet.label,
+              }
+            )}
+            key={snippet.label}
+            onClick={() => setActive(snippet)}
+          >
+            {snippet.label}
+          </div>
+        ))}
       {children}
     </div>
   )

--- a/packages/ui/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/ui/src/components/radio-group/radio-group.stories.tsx
@@ -5,9 +5,9 @@ import { Label } from "@/components/label"
 import { Text } from "@/components/text"
 import { RadioGroup } from "./radio-group"
 
-const meta: Meta<typeof RadioGroup.Root> = {
+const meta: Meta<typeof RadioGroup> = {
   title: "Components/RadioGroup",
-  component: RadioGroup.Root,
+  component: RadioGroup,
   parameters: {
     layout: "centered",
   },
@@ -15,16 +15,16 @@ const meta: Meta<typeof RadioGroup.Root> = {
 
 export default meta
 
-type Story = StoryObj<typeof RadioGroup.Root>
+type Story = StoryObj<typeof RadioGroup>
 
 export const Default: Story = {
   render: () => {
     return (
-      <RadioGroup.Root>
+      <RadioGroup>
         <RadioGroup.Item value="1" />
         <RadioGroup.Item value="2" />
         <RadioGroup.Item value="3" />
-      </RadioGroup.Root>
+      </RadioGroup>
     )
   },
 }
@@ -32,7 +32,7 @@ export const Default: Story = {
 export const WithLabel: Story = {
   render: () => {
     return (
-      <RadioGroup.Root>
+      <RadioGroup>
         <div className="flex items-center gap-x-3">
           <RadioGroup.Item value="1" id="radio_1" />
           <Label htmlFor="radio_1" weight="plus">
@@ -51,7 +51,7 @@ export const WithLabel: Story = {
             Radio 3
           </Label>
         </div>
-      </RadioGroup.Root>
+      </RadioGroup>
     )
   },
 }
@@ -59,7 +59,7 @@ export const WithLabel: Story = {
 export const WithLabelAndDescription: Story = {
   render: () => {
     return (
-      <RadioGroup.Root>
+      <RadioGroup>
         <div className="flex items-start gap-x-3">
           <RadioGroup.Item value="1" id="radio_1" />
           <div className="flex flex-col gap-y-0.5">
@@ -93,7 +93,7 @@ export const WithLabelAndDescription: Story = {
             </Text>
           </div>
         </div>
-      </RadioGroup.Root>
+      </RadioGroup>
     )
   },
 }
@@ -101,11 +101,11 @@ export const WithLabelAndDescription: Story = {
 export const Disabled: Story = {
   render: () => {
     return (
-      <RadioGroup.Root>
+      <RadioGroup>
         <RadioGroup.Item value="1" disabled />
         <RadioGroup.Item value="2" />
         <RadioGroup.Item value="3" disabled checked />
-      </RadioGroup.Root>
+      </RadioGroup>
     )
   },
 }

--- a/packages/ui/src/components/radio-group/radio-group.tsx
+++ b/packages/ui/src/components/radio-group/radio-group.tsx
@@ -22,7 +22,7 @@ Root.displayName = "RadioGroup.Root"
 const Item = React.forwardRef<
   React.ElementRef<typeof Primitives.Item>,
   React.ComponentPropsWithoutRef<typeof Primitives.Item>
->(({ className, children, ...props }, ref) => {
+>(({ className, ...props }, ref) => {
   return (
     <Primitives.Item
       ref={ref}
@@ -46,7 +46,6 @@ const Item = React.forwardRef<
 })
 Item.displayName = "RadioGroup.Item"
 
-export const RadioGroup = {
-  Root,
-  Item,
-}
+const RadioGroup = Object.assign(Root, { Item })
+
+export { RadioGroup }


### PR DESCRIPTION
Also: 
- changes `RadioGroup` to not explicitly have a `Root` property anymore, same as the newer components
- updates `CodeBlock.Header` to take a `hideLabels` property, allowing turning off of snippet labels, useful when header is desired but snippet label may not be, if only one snippet.