### PR TITLE
docs: Hooks pages and examples

### DIFF
--- a/apps/docs/src/config/docs.ts
+++ b/apps/docs/src/config/docs.ts
@@ -219,15 +219,11 @@ export const docsConfig: DocsConfig = {
         {
           title: "usePrompt",
           href: "/hooks/use-prompt",
-          label: "WIP",
-          disabled: true,
           items: [],
         },
         {
           title: "useToast",
           href: "/hooks/use-toast",
-          label: "WIP",
-          disabled: true,
           items: [],
         },
         {

--- a/apps/docs/src/config/docs.ts
+++ b/apps/docs/src/config/docs.ts
@@ -229,8 +229,6 @@ export const docsConfig: DocsConfig = {
         {
           title: "useToggleState",
           href: "/hooks/use-toggle-state",
-          label: "WIP",
-          disabled: true,
           items: [],
         },
       ],

--- a/apps/docs/src/content/docs/components/focus-modal.mdx
+++ b/apps/docs/src/content/docs/components/focus-modal.mdx
@@ -28,7 +28,7 @@ component: true
 
 ---
 
-This component is based on the [Radix UI Dialog]("https://www.radix-ui.com/primitives/docs/components/dialog") primitives.
+This component is based on the [Radix UI Dialog](https://www.radix-ui.com/primitives/docs/components/dialog) primitives.
 
 ### FocusModal.Header
 

--- a/apps/docs/src/content/docs/components/focus-modal.mdx
+++ b/apps/docs/src/content/docs/components/focus-modal.mdx
@@ -14,13 +14,13 @@ component: true
 
 <Snippet>
   ```
-  <FocusModal.Root>
+  <FocusModal>
     <FocusModal.Trigger>Trigger</FocusModal.Trigger>
     <FocusModal.Content>
       <FocusModal.Header>Title</FocusModal.Header>
       <FocusModal.Body>Content</FocusModal.Body>
     </FocusModal.Content>
-  </FocusModal.Root>
+  </FocusModal>
   ```
 </Snippet>
 

--- a/apps/docs/src/content/docs/hooks/use-prompt.mdx
+++ b/apps/docs/src/content/docs/hooks/use-prompt.mdx
@@ -1,0 +1,51 @@
+---
+title: "usePrompt"
+description: ""
+component: true
+---
+
+<br />
+
+This hook can be used to prompt the user for confirmation of an action.
+
+## Usage
+
+---
+
+<Snippet>`import {usePrompt} from "@medusajs/ui"`</Snippet>
+
+<Snippet>
+```
+const dialog = usePrompt()
+const actionFunction = async () {
+  const confirmed = await dialog({
+    title: "Are you sure?",
+    description: "Please confirm this action"
+  })
+}
+```
+</Snippet>
+
+## API Reference
+
+---
+
+### usePrompt
+
+<HookValues hook="usePrompt" />
+
+### PromptProps
+
+<HookValues hook="PromptProps" />
+
+## Examples
+
+---
+
+### Basic
+
+<ComponentExample name="use-prompt-demo" />
+
+### With Verification
+
+<ComponentExample name="use-prompt-verification" />

--- a/apps/docs/src/content/docs/hooks/use-toast.mdx
+++ b/apps/docs/src/content/docs/hooks/use-toast.mdx
@@ -1,0 +1,27 @@
+---
+title: "useToast"
+description: ""
+component: true
+---
+
+<br />
+
+This hook is used to display and manage toasts. To learn how to make it usable and to see some examples, please check the [Toast component page](/components/toast).
+
+<br />
+
+<Snippet>`import {useToast} from "@medusajs/ui"`</Snippet>
+
+## API Reference
+
+---
+
+### useToast
+
+<HookValues hook="useToast" />
+
+### ToasterToast
+
+Important type used when pushing or retrieving toasts. This extends the [Radix UI Toast Root](https://www.radix-ui.com/primitives/docs/components/toast#root) primitive type.
+
+<HookValues hook="ToasterToast" />

--- a/apps/docs/src/content/docs/hooks/use-toggle-state.mdx
+++ b/apps/docs/src/content/docs/hooks/use-toggle-state.mdx
@@ -3,3 +3,35 @@ title: "useToggleState"
 description: ""
 component: true
 ---
+
+<br />
+
+This is a simple hook that can be used to keep track of a boolean value and toggle between its two states.
+
+<br />
+It can be useful to, for example, display or hide the same `FocusModal` component
+via multiple triggers, e.g. in a table.
+
+## Usage
+
+<Snippet>`import {useToggleState} from "@medusajs/ui"`</Snippet>
+
+<Snippet>``` const [state, open, close, toggle] = useToggleState() ```</Snippet>
+
+## API Reference
+
+---
+
+### Args
+
+<ComponentProps component="useToggleState" />
+
+### Returns
+
+<HookValues hook="useToggleState" />
+
+## Examples
+
+---
+
+<ComponentExample name="use-toggle-state-demo" />

--- a/apps/docs/src/content/docs/hooks/use-toggle-state.mdx
+++ b/apps/docs/src/content/docs/hooks/use-toggle-state.mdx
@@ -1,0 +1,5 @@
+---
+title: "useToggleState"
+description: ""
+component: true
+---

--- a/apps/docs/src/examples/focus-modal-demo.tsx
+++ b/apps/docs/src/examples/focus-modal-demo.tsx
@@ -2,7 +2,7 @@ import { Button, FocusModal, Heading, Input, Label, Text } from "@medusajs/ui"
 
 export default function FocusModalDemo() {
   return (
-    <FocusModal.Root>
+    <FocusModal>
       <FocusModal.Trigger asChild>
         <Button>Edit Variant</Button>
       </FocusModal.Trigger>
@@ -28,6 +28,6 @@ export default function FocusModalDemo() {
           </div>
         </FocusModal.Body>
       </FocusModal.Content>
-    </FocusModal.Root>
+    </FocusModal>
   )
 }

--- a/apps/docs/src/examples/use-prompt-demo.tsx
+++ b/apps/docs/src/examples/use-prompt-demo.tsx
@@ -1,0 +1,17 @@
+import { Button, usePrompt } from "@medusajs/ui"
+
+export default function usePromptDemo() {
+  const dialog = usePrompt()
+
+  const deleteEntity = async () => {
+    const userHasConfirmed = await dialog({
+      title: "Please confirm",
+      description: "Are you sure you want to do this?",
+    })
+    if (userHasConfirmed) {
+      // Perform Delete
+    }
+  }
+
+  return <Button onClick={() => deleteEntity()}>Delete Entity</Button>
+}

--- a/apps/docs/src/examples/use-prompt-verification.tsx
+++ b/apps/docs/src/examples/use-prompt-verification.tsx
@@ -1,0 +1,21 @@
+import { Button, usePrompt } from "@medusajs/ui"
+
+export default function usePromptVerification() {
+  const entityName = "foo-bar-baz"
+
+  const dialog = usePrompt()
+
+  const deleteEntity = async () => {
+    const userHasConfirmed = await dialog({
+      title: "Please confirm",
+      description: "Are you sure you want to delete this entity?",
+      verificationText: entityName,
+    })
+    console.log({ userHasConfirmed })
+    if (userHasConfirmed) {
+      // Perform Delete
+    }
+  }
+
+  return <Button onClick={() => deleteEntity()}>Delete {entityName}</Button>
+}

--- a/apps/docs/src/examples/use-toggle-state-demo.tsx
+++ b/apps/docs/src/examples/use-toggle-state-demo.tsx
@@ -1,0 +1,67 @@
+import {
+  Button,
+  FocusModal,
+  Heading,
+  Table,
+  useToggleState,
+} from "@medusajs/ui"
+import { useState } from "react"
+
+export default function useToggleStateDemo() {
+  const [editOpen, showEdit, closeEdit] = useToggleState()
+  const [entityToEdit, setEntityToEdit] = useState<string>()
+
+  const entities = ["foo", "bar", "baz"]
+
+  const editEntity = (entity: string) => {
+    setEntityToEdit(entity)
+    showEdit()
+  }
+
+  const onSave = () => {
+    // do entity update, etc.
+    closeEdit()
+  }
+
+  return (
+    <>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Entity Name</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Actions</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {entities.map((entity) => (
+            <Table.Row>
+              <Table.Cell>{entity}</Table.Cell>
+              <Table.Cell className="text-right">
+                <Button variant="secondary" onClick={() => editEntity(entity)}>
+                  Edit
+                </Button>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      <FocusModal
+        open={editOpen}
+        onOpenChange={(modalOpened) => {
+          if (!modalOpened) closeEdit()
+        }}
+      >
+        <FocusModal.Content>
+          <FocusModal.Header>
+            <Button onClick={() => onSave()}>Save</Button>
+          </FocusModal.Header>
+          <FocusModal.Body>
+            <div className="p-10">
+              <Heading>Edit {entityToEdit}</Heading>
+            </div>
+          </FocusModal.Body>
+        </FocusModal.Content>
+      </FocusModal>
+    </>
+  )
+}

--- a/apps/docs/src/props/hooks/PromptProps.tsx
+++ b/apps/docs/src/props/hooks/PromptProps.tsx
@@ -1,0 +1,34 @@
+import { HookTable } from "@/components/hook-table"
+import { HookDataMap } from "@/types/hooks"
+
+const PromptPropsValues: HookDataMap = [
+  {
+    value: "title",
+    type: "string",
+  },
+  {
+    value: "description",
+    type: "string",
+  },
+  {
+    value: "verificationText",
+    type: "string",
+    description: "Text the user has to input in order to confirm the action",
+  },
+  {
+    value: "cancelText",
+    type: "string",
+    description: 'Label for the Cancel button. Defaults to "Cancel".',
+  },
+  {
+    value: "confirmText",
+    type: "string",
+    description: 'Label for the Confirm button. Defaults to "Confirm".',
+  },
+]
+
+const Props = () => {
+  return <HookTable props={PromptPropsValues} />
+}
+
+export default Props

--- a/apps/docs/src/props/hooks/ToasterToast.tsx
+++ b/apps/docs/src/props/hooks/ToasterToast.tsx
@@ -1,0 +1,44 @@
+import { HookTable } from "@/components/hook-table"
+import { HookDataMap } from "@/types/hooks"
+
+const ToasterToastValues: HookDataMap = [
+  {
+    value: "id",
+    type: "string",
+  },
+  {
+    value: "title",
+    type: "ReactNode",
+  },
+  {
+    value: "description",
+    type: "ReactNode",
+  },
+  {
+    value: "variant",
+    type: {
+      type: "enum",
+      values: ["info", "success", "warning", "error", "loading"],
+    },
+    description: 'Defaults to "info"',
+  },
+  {
+    value: "action",
+    type: {
+      type: "object",
+      name: "ToastActionElement",
+      shape:
+        "{\n  label: string\n  altText: string\n  onClick: () => void | Promise<void>\n}",
+    },
+  },
+  {
+    value: "disableDismiss",
+    type: "boolean",
+  },
+]
+
+const Props = () => {
+  return <HookTable props={ToasterToastValues} />
+}
+
+export default Props

--- a/apps/docs/src/props/hooks/usePrompt.tsx
+++ b/apps/docs/src/props/hooks/usePrompt.tsx
@@ -1,0 +1,19 @@
+import { HookTable } from "@/components/hook-table"
+import { HookDataMap } from "@/types/hooks"
+
+const useToastValues: HookDataMap = [
+  {
+    value: "dialog",
+    type: {
+      type: "function",
+      signature: `async (props: PromptProps): Promise<boolean>`,
+    },
+    description: "Async function used to display a new confirmation dialog.",
+  },
+]
+
+const Props = () => {
+  return <HookTable props={useToastValues} />
+}
+
+export default Props

--- a/apps/docs/src/props/hooks/useToast.tsx
+++ b/apps/docs/src/props/hooks/useToast.tsx
@@ -1,0 +1,35 @@
+import { HookTable } from "@/components/hook-table"
+import { HookDataMap } from "@/types/hooks"
+
+const useToastValues: HookDataMap = [
+  {
+    value: "toast",
+    type: {
+      type: "function",
+      signature:
+        '(toast: Omit<ToasterToast, "id">) => {\n  id: string,\n  dismiss: () => void,\n  update: (toast: ToasterToast) => void\n}',
+    },
+    description:
+      "Function used to display new toasts. For the toast options, please check the ToasterToast reference below.",
+  },
+  {
+    value: "dismiss",
+    type: {
+      type: "function",
+      signature: "(toastId?: string) => void",
+    },
+    description: "Function used to hide a toast based on its id.",
+  },
+  {
+    value: "toasts",
+    type: "ToasterToast[]",
+    description:
+      "All the toasts that have been pushed to the context this hook was invoked in.",
+  },
+]
+
+const Props = () => {
+  return <HookTable props={useToastValues} />
+}
+
+export default Props

--- a/apps/docs/src/props/hooks/useToggleState.tsx
+++ b/apps/docs/src/props/hooks/useToggleState.tsx
@@ -1,0 +1,48 @@
+import { HookTable } from "@/components/hook-table"
+import { HookDataMap } from "@/types/hooks"
+
+const useToggleStateValues: HookDataMap = [
+  {
+    value: "state",
+    type: "boolean",
+  },
+  {
+    value: "open",
+    type: {
+      type: "function",
+      signature: "() => void",
+    },
+  },
+  {
+    value: "close",
+    type: {
+      type: "function",
+      signature: "() => void",
+    },
+  },
+  {
+    value: "toggle",
+    type: {
+      type: "function",
+      signature: "() => void",
+    },
+  },
+]
+
+const useToggleStateValuesArray: HookDataMap = [
+  {
+    value: "state",
+    type: {
+      type: "object",
+      name: "StateData",
+      shape:
+        "[\n  state: boolean,\n  open: () => void,\n  close: () => void,\n  toggle: () => void\n]",
+    },
+  },
+]
+
+const Props = () => {
+  return <HookTable props={useToggleStateValuesArray} />
+}
+
+export default Props

--- a/apps/docs/src/props/useToggleState.tsx
+++ b/apps/docs/src/props/useToggleState.tsx
@@ -1,0 +1,16 @@
+import { PropTable } from "@/components/props-table"
+import { PropDataMap } from "@/types/props"
+
+const useToggleStateProps: PropDataMap = [
+  {
+    prop: "initial",
+    type: "boolean",
+    defaultValue: false,
+  },
+]
+
+const Props = () => {
+  return <PropTable props={useToggleStateProps} />
+}
+
+export default Props

--- a/apps/docs/src/registries/example-registry.tsx
+++ b/apps/docs/src/registries/example-registry.tsx
@@ -504,4 +504,14 @@ export const ExampleRegistry: Record<string, any> = {
     component: React.lazy(() => import("@/examples/dropdown-menu-sorting")),
     file: "src/examples/dropdown-menu-sorting.tsx",
   },
+  "use-prompt-demo": {
+    name: "use-prompt-demo",
+    component: React.lazy(() => import("@/examples/use-prompt-demo")),
+    file: "src/examples/use-prompt-demo.tsx",
+  },
+  "use-prompt-verification": {
+    name: "use-prompt-demo",
+    component: React.lazy(() => import("@/examples/use-prompt-verification")),
+    file: "src/examples/use-prompt-verification.tsx",
+  },
 }

--- a/apps/docs/src/registries/example-registry.tsx
+++ b/apps/docs/src/registries/example-registry.tsx
@@ -514,4 +514,9 @@ export const ExampleRegistry: Record<string, any> = {
     component: React.lazy(() => import("@/examples/use-prompt-verification")),
     file: "src/examples/use-prompt-verification.tsx",
   },
+  "use-toggle-state-demo": {
+    name: "use-toggle-state",
+    component: React.lazy(() => import("@/examples/use-toggle-state-demo")),
+    file: "src/examples/use-toggle-state-demo.tsx",
+  },
 }

--- a/apps/docs/src/registries/hook-registry.tsx
+++ b/apps/docs/src/registries/hook-registry.tsx
@@ -17,4 +17,7 @@ export const HookRegistry: Record<string, HookRegistryItem> = {
   PromptProps: {
     table: React.lazy(() => import("../props/hooks/PromptProps")),
   },
+  useToggleState: {
+    table: React.lazy(() => import("../props/hooks/useToggleState")),
+  },
 }

--- a/apps/docs/src/registries/hook-registry.tsx
+++ b/apps/docs/src/registries/hook-registry.tsx
@@ -5,4 +5,16 @@ export const HookRegistry: Record<string, HookRegistryItem> = {
   useSelectContext: {
     table: React.lazy(() => import("../props/hooks/useSelectContext")),
   },
+  useToast: {
+    table: React.lazy(() => import("../props/hooks/useToast")),
+  },
+  ToasterToast: {
+    table: React.lazy(() => import("../props/hooks/ToasterToast")),
+  },
+  usePrompt: {
+    table: React.lazy(() => import("../props/hooks/usePrompt")),
+  },
+  PromptProps: {
+    table: React.lazy(() => import("../props/hooks/PromptProps")),
+  },
 }

--- a/apps/docs/src/registries/prop-registry.tsx
+++ b/apps/docs/src/registries/prop-registry.tsx
@@ -68,4 +68,7 @@ export const PropRegistry: Record<string, PropRegistryItem> = {
   tooltip: {
     table: React.lazy(() => import("../props/tooltip")),
   },
+  useToggleState: {
+    table: React.lazy(() => import("../props/useToggleState")),
+  },
 }

--- a/packages/ui/src/components/focus-modal/focus-modal.tsx
+++ b/packages/ui/src/components/focus-modal/focus-modal.tsx
@@ -93,10 +93,11 @@ const Body = ({
 }
 Body.displayName = "FocusModal.Body"
 
-export const FocusModal = {
-  Root,
+const FocusModal = Object.assign(Root, {
   Trigger,
   Content,
   Header,
   Body,
-}
+})
+
+export { FocusModal }

--- a/packages/ui/src/components/prompt/prompt.tsx
+++ b/packages/ui/src/components/prompt/prompt.tsx
@@ -42,7 +42,9 @@ const Title = React.forwardRef<
 >(({ className, children, ...props }, ref) => {
   return (
     <Primitives.Title ref={ref} className={clx(className)} {...props} asChild>
-      <Heading level="h2">{children}</Heading>
+      <Heading level="h2" className="text-ui-fg-base">
+        {children}
+      </Heading>
     </Primitives.Title>
   )
 })
@@ -76,7 +78,7 @@ const Description = React.forwardRef<
   return (
     <Primitives.Description
       ref={ref}
-      className={clx("text-subtle txt-compact-medium", className)}
+      className={clx("text-ui-fg-subtle txt-compact-medium", className)}
       {...props}
     />
   )
@@ -86,10 +88,10 @@ Description.displayName = "Prompt.Description"
 const Action = React.forwardRef<
   React.ElementRef<typeof Primitives.Action>,
   Omit<React.ComponentPropsWithoutRef<typeof Primitives.Action>, "asChild">
->(({ className, children, ...props }, ref) => {
+>(({ className, children, type, ...props }, ref) => {
   return (
     <Primitives.Action ref={ref} className={className} {...props} asChild>
-      <Button>{children}</Button>
+      <Button type={type}>{children}</Button>
     </Primitives.Action>
   )
 })

--- a/packages/ui/src/hooks/use-prompt/dialog.tsx
+++ b/packages/ui/src/hooks/use-prompt/dialog.tsx
@@ -44,6 +44,10 @@ const Dialog = ({
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
+    if (!verificationText) {
+      return
+    }
+
     if (validInput) {
       onConfirm()
     }
@@ -66,14 +70,14 @@ const Dialog = ({
   return (
     <Prompt open={open}>
       <Prompt.Content>
-        <Prompt.Header>
-          <Prompt.Title>{title}</Prompt.Title>
-          <Prompt.Description>{description}</Prompt.Description>
-        </Prompt.Header>
-        {verificationText && (
-          <form onSubmit={handleFormSubmit}>
-            <fieldset className="border-ui-border-base mt-6 flex flex-col gap-y-4 border-y p-6">
-              <Label htmlFor="verificationText" className="text-subtle">
+        <form onSubmit={handleFormSubmit}>
+          <Prompt.Header>
+            <Prompt.Title>{title}</Prompt.Title>
+            <Prompt.Description>{description}</Prompt.Description>
+          </Prompt.Header>
+          {verificationText && (
+            <div className="border-ui-border-base mt-6 flex flex-col gap-y-4 border-y p-6">
+              <Label htmlFor="verificationText" className="text-ui-fg-subtle">
                 Please type{" "}
                 <span className="text-ui-fg-base txt-compact-medium-plus">
                   {verificationText}
@@ -87,19 +91,19 @@ const Dialog = ({
                 placeholder={verificationText}
                 onChange={handleUserInput}
               />
-            </fieldset>
-          </form>
-        )}
-        <Prompt.Footer>
-          <Prompt.Cancel onClick={onCancel}>{cancelText}</Prompt.Cancel>
-          <Prompt.Action
-            onClick={verificationText ? undefined : onConfirm}
-            disabled={!validInput}
-            type={verificationText ? "submit" : "button"}
-          >
-            {confirmText}
-          </Prompt.Action>
-        </Prompt.Footer>
+            </div>
+          )}
+          <Prompt.Footer>
+            <Prompt.Cancel onClick={onCancel}>{cancelText}</Prompt.Cancel>
+            <Prompt.Action
+              disabled={!validInput}
+              type={verificationText ? "submit" : "button"}
+              onClick={verificationText ? undefined : onConfirm}
+            >
+              {confirmText}
+            </Prompt.Action>
+          </Prompt.Footer>
+        </form>
       </Prompt.Content>
     </Prompt>
   )

--- a/packages/ui/src/hooks/use-prompt/use-prompt.tsx
+++ b/packages/ui/src/hooks/use-prompt/use-prompt.tsx
@@ -6,10 +6,10 @@ import { DialogProps } from "./dialog"
 
 import Dialog from "./dialog"
 
-type UsePromptProps = Omit<DialogProps, "onConfirm" | "onCancel" | "open">
+type PromptProps = Omit<DialogProps, "onConfirm" | "onCancel" | "open">
 
 const usePrompt = () => {
-  const dialog = async (props: UsePromptProps): Promise<boolean> => {
+  const dialog = async (props: PromptProps): Promise<boolean> => {
     return new Promise((resolve) => {
       let open = true
 


### PR DESCRIPTION
Adds some content for the hooks docs pages alongside some examples where relevant.

Also:
- renames `UsePromptProps` type to `PromptProps` within `usePrompt`, as this felt a bit more sensible, as they are not props used for the hook directly, but rather for the prompt/dialog being triggered from the returned function.
- assigns the `Root` in `FocusModal` directly to `FocusModal`, as in the newer components.