### PR TITLE
fix(DatePicker): add type=button to days

### DIFF
--- a/packages/ui/src/components/calendar/calendar.tsx
+++ b/packages/ui/src/components/calendar/calendar.tsx
@@ -121,6 +121,7 @@ const Day = ({ date, displayMonth }: DayProps) => {
   return (
     <button
       ref={ref}
+      type="button"
       {...buttonPropsRest}
       className={clx("relative", buttonClassName)}
     >


### PR DESCRIPTION
This prevents clicks on days from triggering `submit` on `form` parents.

closes #84